### PR TITLE
Fix: Restrict workflow permissions for enhanced security

### DIFF
--- a/.github/workflows/bazel-test.yml
+++ b/.github/workflows/bazel-test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run Bazel Tests


### PR DESCRIPTION
I've added the `permissions` key to the `bazel-test.yml` workflow file and set `contents: read`.

This change adheres to the principle of least privilege by explicitly granting only the necessary read access to the repository for the workflow, rather than relying on potentially overly permissive default permissions.